### PR TITLE
Automatically escape arguments when necessary

### DIFF
--- a/rsync.js
+++ b/rsync.js
@@ -383,12 +383,12 @@ Rsync.prototype.args = function() {
 
     // Add sources
     if (this.source().length > 0) {
-        args = args.concat(this.source());
+        args = args.concat(this.source().map(escapeShellArg));
     }
 
     // Add destination
     if (this.destination()) {
-        args.push(this.destination());
+        args.push(escapeShellArg(this.destination()));
     }
 
     return args;
@@ -757,13 +757,9 @@ function exposeLongOption(option, name) {
  * Build an option for use in a shell command.
  * @param {String} name
  * @param {String} value
- * @param {Boolean} escape
  * @return {String}
  */
-function buildOption(name, value, escape) {
-    // Make sure the escape argument is a Boolean
-    escape = (typeof esacpe === 'boolean') ? escape : true;
-
+function buildOption(name, value) {
     // Detect single option key
     var single = (name.length === 1) ? true : false;
 
@@ -774,7 +770,7 @@ function buildOption(name, value, escape) {
     // Build the option
     var option = prefix + name;
     if (arguments.length > 1 && value) {
-        value   = (!escape) ? String(value) : escapeShellArg(String(value));
+        value   = escapeShellArg(String(value));
         option += glue + value;
     }
 
@@ -782,14 +778,15 @@ function buildOption(name, value, escape) {
 }
 
 /**
- * Escape an argument for use in a shell command.
+ * Escape an argument for use in a shell command when necessary.
  * @param {String} arg
- * @param {String} char
  * @return {String}
  */
-function escapeShellArg(arg, char) {
-  char = char || '"';
-  return char + arg.replace(/(["'`\\])/g, '\\$1') + char;
+function escapeShellArg(arg) {
+  if (!/(["'`\\$ ])/.test(arg)) {
+    return arg;
+  }
+  return '"' + arg.replace(/(["'`\\$])/g, '\\$1') + '"';
 }
 
 /**

--- a/tests/escape.test.js
+++ b/tests/escape.test.js
@@ -4,7 +4,7 @@ var Rsync  = require('../rsync');
 // Setups to test escaping
 var setups = [
   {
-    expect: 'rsync -avz --exclude="no-go.txt" --exclude="with space" --exclude=".git" --exclude="*.tiff" path_a/ path_b',
+    expect: 'rsync -avz --exclude=no-go.txt --exclude="with space" --exclude=.git --exclude=*.tiff path_a/ path_b',
     build: function() {
       return new Rsync()
         .flags('avz')


### PR DESCRIPTION
This fixes some very minor issues that I saw when using `node-rsync` on a
recent project.

Firstly, `npm test` doesn't run because the `test` directory is actually named
`tests`. I renamed it back to `test` since it is mocha's default.

Second, there is a typo in `buildOption()` for a parameter that is never used
in the code. I got rid of the parameter since it is currently causing every
value passed into `buildOption()` to be escaped.

Finally, I looked at `escapeShellArg()` since I was having issues with source
paths that contained spaces causing the rsync command to fail. Rather than
escaping every path, I modified `escapeShellArg` to determine whether the
argument needed to be escaped. I was able to safely apply this logic to the
values in `buildOption()`, source paths, and the destination. I also updated
the test since the behavior changed a bit.
