### PR TITLE
Updated pull to return child process object

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,11 @@ These methods can be used to get or set values in a chainable way. When the meth
 
 Get or set the executable to use as the rsync command.
 
-### unixshell(shell)
+### executableShell(shell)
 
-Get or set the shell to use to launch the rsync command on non-Windows systems.
+Get or set the shell to use to launch the rsync command on non-Windows (Unix and Mac OS X) systems.  The default shell is /bin/sh.  
+
+On some systems (Debian, for example) /bin/sh links to /bin/dash, which does not do proper process control.  If you have problems with leftover processes, try a different shell such as /bin/bash.
 
 ### destination(destination)
 

--- a/rsync.js
+++ b/rsync.js
@@ -54,7 +54,7 @@ function Rsync(config) {
     this._executable = hasOP(config, 'executable') ? config.executable : 'rsync';
 
     // shell
-    this._unixshell = hasOP(config, 'unixshell') ? config.unixshell : '/bin/sh';
+    this._executableShell = hasOP(config, 'executableShell') ? config.executableShell : '/bin/sh';
 
     // source(s) and destination
     this._sources     = [];
@@ -448,7 +448,7 @@ Rsync.prototype.execute = function(callback, stdoutHandler, stderrHandler) {
                         { stdio: 'pipe', windowsVerbatimArguments: true });
     }
     else {
-        cmdProc = spawn(this._unixshell, ['-c', this.command()],
+        cmdProc = spawn(this._executableShell, ['-c', this.command()],
                         { stdio: 'pipe' });
     }
 
@@ -511,18 +511,18 @@ createValueAccessor('debug');
 createValueAccessor('executable');
 
 /**
- * Get or set the shell to use on non-Windows systems.
+ * Get or set the shell to use on non-Windows (Unix or Mac OS X) systems.
  *
  * When setting the shell the Rsync instance is returned for the 
  * fluent interface. Otherwise the configured shell is returned.
  *
  * @function
- * @name unixshell
+ * @name executableShell
  * @memberOf Rsync.prototype
  * @param {String} shell to use on non-Windows systems (optional)
  * @return {Rsync|String}
  */
-createValueAccessor('unixshell');
+createValueAccessor('executableShell');
 
 /**
  * Get or set the destination for the transfer.


### PR DESCRIPTION
Hi - I've updated my changes to add an option 'unixshell' for setting the shell used to run rsync (the 'shell' option already exists), and split the change to return the child process object into a separate commit.  The default 'unixshell' is still /bin/sh.

I've also included changes to the README.md to document the new options.
