### PR TITLE
For escapeShellArg, only wrap with double quotes.  

### DIFF
--- a/rsync.js
+++ b/rsync.js
@@ -519,7 +519,7 @@ createValueAccessor('executable');
 /**
  * Get or set the shell to use on non-Windows (Unix or Mac OS X) systems.
  *
- * When setting the shell the Rsync instance is returned for the 
+ * When setting the shell the Rsync instance is returned for the
  * fluent interface. Otherwise the configured shell is returned.
  *
  * @function
@@ -799,10 +799,11 @@ function buildOption(name, value, escapeArg) {
  * @return {String}
  */
 function escapeShellArg(arg) {
-  if (!/(["'`\\$ ])/.test(arg)) {
-    return arg;
-  }
-  return '"' + arg.replace(/(["'`\\$])/g, '\\$1') + '"';
+  //if (!/(["'`\\$ ])/.test(arg)) {
+  //  return arg;
+  //}
+  //return '"' + arg.replace(/(["'`\\$])/g, '\\$1') + '"';
+  return '"' + arg + '"';
 }
 
 /**


### PR DESCRIPTION
It should be sufficient to wrap characters that would be escaped with double quotes.  

ie: from command line, this works:

`rsync -avzs --rsh="ssh -p 22 -i ~/.ssh/key.pem -o StrictHostKeyChecking=no" "user@host:/tmp/File Info for 'My User'.xlsx" "/tmp/tmpfile.xlsx"`

and this change works for all of my cases.