### PR TITLE
Options and flags for setting file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ The following option shorthand methods are available:
   - **dirs()**: `-d`
   - **links()**: `-l`
   - **dry()**: `-n`
+  - **chmod(value)**: --chmod=VALUE (accumulative)
+  - **perms()**: -p
 
 All shorthand methods are chainable as long as options that require a value are provided with one.
 
@@ -363,7 +365,7 @@ If there is something missing (which there probably is) just fork, patch and sen
 
 For adding a new shorthand method there are a few simple steps to take:
 - Fork
-- Add the option through the `exposeShortOption` or `exposeLongOption` functions. For examples see the source file.
+- Add the option through the `exposeShortOption`, `exposeLongOption` or `exposeMultiOption` functions. For examples see the source file.
 - Update this README file to list the new shorthand method
 - Make a pull request
 

--- a/README.md
+++ b/README.md
@@ -234,8 +234,18 @@ The following option shorthand methods are available:
   - **dirs()**: `-d`
   - **links()**: `-l`
   - **dry()**: `-n`
-  - **chmod(value)**: --chmod=VALUE (accumulative)
-  - **perms()**: -p
+  - **chmod(value)**: `--chmod=VALUE` (accumulative)
+  - **hardLinks()**: `-H`
+  - **perms()**: `-p`
+  - **executability()**: `-E`
+  - **owner()**: `-o`
+  - **group()**: `-g`
+  - **acls()**: `-A`
+  - **xattrs()**: `-X`
+  - **devices()**: `--devices`
+  - **specials**: `--specials`
+  - **times()**: `-t`
+
 
 All shorthand methods are chainable as long as options that require a value are provided with one.
 

--- a/rsync.js
+++ b/rsync.js
@@ -697,6 +697,16 @@ exposeShortOption('l', 'links');
 exposeShortOption('n', 'dry');
 
 /**
+ * Set the hard links flag preserving hard links for the files transmitted.
+ *
+ * @function
+ * @name hardLinks
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('H', 'hardLinks');
+
+/**
  * Set the perms flag.
  *
  * @function
@@ -706,6 +716,88 @@ exposeShortOption('n', 'dry');
  */
 exposeShortOption('p', 'perms');
 
+/**
+ * Set the executability flag to preserve executability for the files
+ * transmitted.
+ *
+ * @function
+ * @name executability
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('E', 'executability');
+
+/**
+ * Set the group flag to preserve the group permissions of the files
+ * transmitted.
+ *
+ * @function
+ * @name group
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('g', 'group');
+
+/**
+ * Set the owner flag to preserve the owner of the files transmitted.
+ *
+ * @function
+ * @name owner
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('o', 'owner');
+
+/**
+ * Set the acls flag to preserve the ACLs for the files transmitted.
+ *
+ * @function
+ * @name acls
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('A', 'acls');
+
+/**
+ * Set the xattrs flag to preserve the extended attributes for the files
+ * transmitted.
+ *
+ * @function
+ * @name xattrs
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('X', 'xattrs');
+
+/**
+ * Set the devices flag to preserve device files in the transfer.
+ *
+ * @function
+ * @name devices
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('devices');
+
+/**
+ * Set the specials flag to preserve special files.
+ *
+ * @function
+ * @name specials
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('specials');
+
+/**
+ * Set the times flag to preserve times for the files in the transfer.
+ *
+ * @function
+ * @name times
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('t', 'times');
 
 // our awesome export product
 module.exports = Rsync;
@@ -795,7 +887,7 @@ function exposeMultiOption(option, name) {
         }
         else {
             // Add the value
-            let current = this.option(option);
+            var current = this.option(option);
             if (!current) {
                 value = [ value ];
             }

--- a/rsync.js
+++ b/rsync.js
@@ -60,6 +60,9 @@ function Rsync(config) {
     this._sources     = [];
     this._destination = '';
 
+    // chmod
+    this._chmod = [];
+
     // ordered list of file patterns to include/exclude
     this._patterns = [];
 
@@ -364,6 +367,13 @@ Rsync.prototype.args = function() {
         }
     }
 
+    // Add chmod as long options
+    if (this._chmod.length > 0) {
+      this._chmod.forEach(function (value) {
+          long.push(buildOption('chmod', value, escapeShellArg));
+      })
+    }
+
     // Add combined short options if any are present
     if (short.length > 0) {
         args.push('-' + short.join(''));
@@ -575,6 +585,17 @@ createListAccessor('source', '_sources');
 exposeLongOption('rsh', 'shell');
 
 /**
+ * Add a chmod instruction to the command.
+ *
+ * @function
+ * @name chmod
+ * @memberOf Rsync.prototype
+ * @param {String|Array}
+ * @return {Rsync|Array}
+ */
+createListAccessor('chmod', '_chmod');
+
+/**
  * Set the delete flag.
  *
  * This is the same as setting the `--delete` commandline flag.
@@ -677,6 +698,17 @@ exposeShortOption('l', 'links');
  * @return {Rsync}
  */
 exposeShortOption('n', 'dry');
+
+/**
+ * Set the perms flag.
+ *
+ * @function
+ * @name perms
+ * @memberOf Rsync.prototype
+ * @return {Rsync}
+ */
+exposeShortOption('p', 'perms');
+
 
 // our awesome export product
 module.exports = Rsync;

--- a/tests/shorthands.test.js
+++ b/tests/shorthands.test.js
@@ -223,6 +223,23 @@ describe('shorthands', function () {
         });
     });
 
+//# hardLinks/////////////////////////////////////////////////////////////////////////////////////
+    describe('#hardLinks', function () {
+
+        it('should add the hard links flag', function () {
+            command.hardLinks();
+            assertOutputPattern(command, /rsync -H/);
+        });
+
+        it('should unset the hard links flag', function () {
+            command.hardLinks();
+            assertOutputPattern(command, /rsync -H/);
+            command.hardLinks(false);
+            assertOutput(command, output);
+        });
+
+    });
+
 //# perms ////////////////////////////////////////////////////////////////////////////////////////
     describe('#perms', function () {
 
@@ -235,6 +252,133 @@ describe('shorthands', function () {
         command.perms();
         assertOutputPattern(command, /rsync -p/);
         command.perms(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#executability', function () {
+
+      it('should add the executability flag', function () {
+        command.executability();
+        assertOutputPattern(command, /rsync -E/);
+      });
+
+      it('should unset the executability flag', function () {
+        command.executability();
+        assertOutputPattern(command, /rsync -E/);
+        command.executability(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#owner', function () {
+
+      it('should add the owner flag', function () {
+        command.owner();
+        assertOutputPattern(command, /rsync -o/);
+      });
+
+      it('should unset the owner flag', function () {
+        command.owner();
+        assertOutputPattern(command, /rsync -o/);
+        command.owner(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#group', function () {
+
+      it('should add the group flag', function () {
+        command.group();
+        assertOutputPattern(command, /rsync -g/);
+      });
+
+      it('should unset the group flag', function () {
+        command.group();
+        assertOutputPattern(command, /rsync -g/);
+        command.group(false);
+        assertOutput(command, output);
+      });
+    });
+
+    describe('#acls', function () {
+
+      it('should set the acls flag', function () {
+        command.acls();
+        assertOutputPattern(command, /rsync -A/);
+      });
+
+      it('should unset the acls flag', function () {
+        command.acls();
+        assertOutputPattern(command, /rsync -A/);
+        command.acls(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#xattrs', function () {
+
+      it('should set the xattrs flag', function () {
+        command.xattrs();
+        assertOutputPattern(command, /rsync -X/);
+      });
+
+      it('should unset the xattrs flag', function () {
+        command.xattrs();
+        assertOutputPattern(command, /rsync -X/);
+        command.xattrs(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#devices', function () {
+
+      it('should set the the devices option', function () {
+        command.devices();
+        assertOutputPattern(command, /rsync --devices/);
+      });
+
+      it('should unset the devices option', function () {
+        command.devices();
+        assertOutputPattern(command, /rsync --devices/);
+        command.devices(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#specials', function () {
+
+      it('should set the the specials option', function () {
+        command.specials();
+        assertOutputPattern(command, /rsync --specials/);
+      });
+
+      it('should unset the specials option', function () {
+        command.specials();
+        assertOutputPattern(command, /rsync --specials/);
+        command.specials(false);
+        assertOutput(command, output);
+      });
+
+    });
+
+    describe('#times', function () {
+
+      it('should set the the times option', function () {
+        command.times();
+        assertOutputPattern(command, /rsync -t/);
+      });
+
+      it('should unset the times option', function () {
+        command.times();
+        assertOutputPattern(command, /rsync -t/);
+        command.times(false);
         assertOutput(command, output);
       });
 

--- a/tests/shorthands.test.js
+++ b/tests/shorthands.test.js
@@ -1,5 +1,6 @@
 "use strict";
 /* global describe, it */
+var assert = require('chai').assert;
 var Rsync = require('../rsync');
 var assertOutput = require('./helpers/output').assertOutput;
 var assertOutputPattern = require('./helpers/output').assertOutputPattern;
@@ -36,6 +37,51 @@ describe('shorthands', function () {
             assertOutput(rsync, 'rsync --rsh="ssh -i /home/user/.ssh/rsync.key" source destination');
       });
   });
+
+//# chmod /////////////////////////////////////////////////////////////////////////////////////////
+    describe('#chmod', function () {
+        var rsync;
+
+        it('should allow a simple value through build', function () {
+            rsync = Rsync.build({
+                'source': 'source',
+                'destination': 'destination',
+                'chmod': 'ug=rwx'
+            });
+            assertOutputPattern(rsync, /chmod=ug=rwx/i);
+        });
+
+        it('should allow multiple values through build', function () {
+            rsync = Rsync.build({
+                'source': 'source',
+                'destination': 'destination',
+                'chmod': [ 'og=uwx', 'rx=ogw' ]
+            });
+            assertOutputPattern(rsync, /chmod=og=uwx --chmod=rx=ogw/);
+        });
+
+        it('should allow multiple values through setter', function () {
+            rsync = Rsync.build({
+                'source': 'source',
+                'destination': 'destination'
+            });
+            rsync.chmod('o=rx');
+            rsync.chmod('ug=rwx');
+            assertOutputPattern(rsync, /--chmod=o=rx --chmod=ug=rwx/);
+        });
+
+        it('should return all the chmod values', function () {
+            var inputValues = [ 'og=uwx', 'rx=ogw' ];
+            rsync = Rsync.build({
+                'source': 'source',
+                'destination': 'destination',
+                'chmod': inputValues
+            });
+
+            var values = rsync.chmod();
+            assert.deepEqual(values, inputValues);
+        });
+    });
 
 //# delete ////////////////////////////////////////////////////////////////////////////////////////
     describe('#delete', function () {
@@ -175,6 +221,23 @@ describe('shorthands', function () {
             command = testSet().dry(false);
             assertOutput(command, output);
         });
+    });
+
+//# perms ////////////////////////////////////////////////////////////////////////////////////////
+    describe('#perms', function () {
+
+      it('should add the perms flag', function () {
+        command.perms();
+        assertOutputPattern(command, /rsync -p/);
+      });
+
+      it('should unset the perms flag', function () {
+        command.perms();
+        assertOutputPattern(command, /rsync -p/);
+        command.perms(false);
+        assertOutput(command, output);
+      });
+
     });
 
 });


### PR DESCRIPTION
Added more shorthands to work with file permissions of the transfered files:

  - **chmod(value)**: `--chmod=VALUE` (accumulative)
  - **hardLinks()**: `-H`
  - **perms()**: `-p`
  - **executability()**: `-E`
  - **owner()**: `-o`
  - **group()**: `-g`
  - **acls()**: `-A`
  - **xattrs()**: `-X`
  - **devices()**: `--devices`
  - **specials**: `--specials`
  - **times()**: `-t`