### PR TITLE
Allow overriding of environment variables for the rsync process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ rsync.cwd(__dirname); // Set cwd to __dirname
 rsync.cwd(); // Get cwd value
 ```
 
+### env(envObj)
+
+Set or get the value for rsync process environment variables.
+
+Default: process.env
+
+```javascript
+rsync.env(process.env); // Set env to process.env
+rsync.env(); // Get env values
+```
+
 ### output(stdoutHandler, stderrHandler)
 
 Register output handler functions for the commands stdout and stderr output. The handlers will be
@@ -393,6 +404,10 @@ When adding a shorthand make sure it does not already exist, it is a sane name a
 If there is something broken (which there probably is), the same applies: fork, patch, pull request. Opening an issue is also possible.
 
 # Changelog
+
+v0.6.0
+
+  - Added env() option to set the process environment variables (#51)
 
 v0.5.0
 

--- a/rsync.js
+++ b/rsync.js
@@ -75,6 +75,9 @@ function Rsync(config) {
 
     this._cwd = process.cwd();
 
+    // Allow child_process.spawn env overriding
+    this._env = process.env;
+
     // Debug parameter
     this._debug = hasOP(config, 'debug') ? config.debug : false;
 }
@@ -429,6 +432,24 @@ Rsync.prototype.cwd = function(cwd) {
 };
 
 /**
+ * Get and set rsync process environment variables
+ *
+ * @param  {string} env= Environment variables
+ * @return {string} Return current _env.
+ */
+Rsync.prototype.env = function(env) {
+    if (arguments.length > 0) {
+        if (typeof env !== 'object') {
+            throw new Error('Environment should be an object');
+        }
+
+        this._env = env;
+    }
+
+    return this._env;
+};
+
+/**
  * Register an output handlers for the commands stdout and stderr streams.
  * These functions will be called once data is streamed on one of the output buffers
  * when the command is executed using `execute`.
@@ -479,11 +500,11 @@ Rsync.prototype.execute = function(callback, stdoutHandler, stderrHandler) {
     var cmdProc;
     if ('win32' === process.platform) {
         cmdProc = spawn('cmd.exe', ['/s', '/c', '"' + this.command() + '"'],
-                        { stdio: 'pipe', windowsVerbatimArguments: true, cwd: this._cwd });
+                        { stdio: 'pipe', windowsVerbatimArguments: true, cwd: this._cwd, env: this._env });
     }
     else {
         cmdProc = spawn(this._executableShell, ['-c', this.command()],
-                        { stdio: 'pipe', cwd: this._cwd });
+                        { stdio: 'pipe', cwd: this._cwd, env: this._env });
     }
 
     // Capture stdout and stderr if there are output handlers configured

--- a/tests/accessors.test.js
+++ b/tests/accessors.test.js
@@ -39,7 +39,7 @@ describe('accessors', function () {
 
     describe('#cwd', function () {
 
-      it('should set the the executable shell to use', function () {
+      it('should set the the cwd to use', function () {
         var rsync = Rsync.build({
           'source':           'a.txt',
           'destination':      'b.txt',
@@ -47,6 +47,20 @@ describe('accessors', function () {
         });
 
         assert.equal(path.resolve(__dirname, '..'), rsync.cwd(), 'cwd was set');
+      });
+
+    });
+
+    describe('#env', function () {
+
+      it('should set the the env variables to use', function () {
+        var rsync = Rsync.build({
+          'source':           'a.txt',
+          'destination':      'b.txt',
+          'env': {'red': 'blue'}
+        });
+
+        assert.equal('blue', rsync.env().red, 'env was set');
       });
 
     });


### PR DESCRIPTION
Provides the ability to override the environment variables passed to child_process.spawn and thus given to rsync.

The default is still `process.env`, which makes this change completely backwards compatible.

Resolves #51 