### PR TITLE
Escape file names that contain "&" characters

### DIFF
--- a/rsync.js
+++ b/rsync.js
@@ -1017,7 +1017,7 @@ function escapeShellArg(arg) {
  * @return {String} the escaped version of the filename
  */
 function escapeFileArg(filename) {
-  filename = filename.replace(/(["'`\s\\\(\)\\$])/g,'\\$1');
+  filename = filename.replace(/(["'`\s\\\(\)\\$\&])/g,'\\$1');
   if (!/(\\\\)/.test(filename)) {
     return filename;
   }


### PR DESCRIPTION
Currently the child process exits with a code 127 when attempting to transfer any files that contain a "&" character. The fix is a trivial change to the file.replace regex.